### PR TITLE
introduce option to prevent exiting insert mode.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ require("stopinsert").setup()
 | `show_popup_msg`      | boolean   | `true`            | Enable/disable popup message" |
 | `clear_popup_ms`      | number   | `5000`            | Maximum time (in milliseconds) for which the popup message hangs around |
 | `disabled_filetypes`  | list     | `{ "TelescopePrompt", "checkhealth", "help", "lspinfo", "mason", "neo%-tree*", }` | List of filetypes to exclude the effect of this plugin. |
+| `stopinsert_guard` | function | `nil` | Optional function that returns a boolean. If true, prevents stopinsert. |
 
 **NOTE:**
 By default, `stopinsert.nvim` excludes a list of filetypes, as shown in the table above.

--- a/lua/stopinsert/config.lua
+++ b/lua/stopinsert/config.lua
@@ -1,9 +1,17 @@
 local M = {}
 
+--- Configuration options for StopInsert
 M.config = {
+   --- Time in milliseconds after which insert mode will be exited if no keys are pressed.
    idle_time_ms = 5000,
+
+   --- Whether to show a popup message when exiting insert mode due to inactivity.
    show_popup_msg = true,
+
+   --- Time in milliseconds after which the popup message will be cleared.
    clear_popup_ms = 5000,
+
+   --- List of filetypes where StopInsert should be disabled.
    disabled_filetypes = {
       "TelescopePrompt",
       "checkhealth",
@@ -12,6 +20,9 @@ M.config = {
       "mason",
       "neo%-tree*",
    },
+
+   --- Optional function that returns a boolean. If true, prevents stopinsert.
+   stopinsert_guard = nil,
 }
 
 ---@param user_config table

--- a/lua/stopinsert/util.lua
+++ b/lua/stopinsert/util.lua
@@ -6,10 +6,15 @@ local popup = require("stopinsert.popup")
 ---@return nil
 function M.force_exit_insert_mode()
    if vim.fn.mode() == "i" then
+      if type(config.stopinsert_guard) == "function" and config.stopinsert_guard() then
+         return
+      end
+
       vim.cmd("stopinsert")
 
       if config.show_popup_msg then
-         local msg = "StopInsertPlug: You were idling in Insert mode. Remember to <Esc> when you finish editing."
+         local msg =
+            "StopInsertPlug: You were idling in Insert mode. Remember to <Esc> when you finish editing."
          popup.show(msg, config.clear_popup_ms)
       end
    end


### PR DESCRIPTION
- Add `stopinsert_guard` option to README
- Add `stopinsert_guard` configuration option
- Add a guard function to prevent exiting insert mode based on a condition