### PR TITLE
Fix timer clearing when disabling stopinsert

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,8 @@ Filetypes can also be listed as regex, such as `neo%-tree*`.
 :StopInsertPlug status
 ```
 
-Each of them does exactly what it says on the tin.
+Each of them does exactly what it says on the tin. When the plugin is disabled,
+any pending idle timer is cleared so you won't be forced back to Normal mode.
 
 ## Contribution
 

--- a/doc/stopinsert.nvim.txt
+++ b/doc/stopinsert.nvim.txt
@@ -109,13 +109,14 @@ USER COMMAND                                    *stopinsert.nvim-user-command*
 with the following commands:
 
 >
-    :StopInsertPlug enable
-    :StopInsertPlug disable
-    :StopInsertPlug toggle
-    :StopInsertPlug status
+   :StopInsertPlug enable
+   :StopInsertPlug disable
+   :StopInsertPlug toggle
+   :StopInsertPlug status
 <
 
-Each of them does exactly what it says on the tin.
+Each of them does exactly what it says on the tin. Disabling the plugin clears
+any pending idle timer so you won't be forced back to Normal mode unexpectedly.
 
 
 CONTRIBUTION                                    *stopinsert.nvim-contribution*

--- a/lua/stopinsert/init.lua
+++ b/lua/stopinsert/init.lua
@@ -1,15 +1,23 @@
 local M = {}
 
 M.enable = true
+local util = require("stopinsert.util")
 local user_cmds = {
    enable = function()
       M.enable = true
+      util.reset_timer()
    end,
    disable = function()
       M.enable = false
+      util.clear_timer()
    end,
    toggle = function()
       M.enable = not M.enable
+      if M.enable then
+         util.reset_timer()
+      else
+         util.clear_timer()
+      end
    end,
    status = function()
       if M.enable then
@@ -21,7 +29,6 @@ local user_cmds = {
 }
 
 local config = require("stopinsert.config")
-local util = require("stopinsert.util")
 
 ---@param opts table
 ---@return nil

--- a/lua/stopinsert/util.lua
+++ b/lua/stopinsert/util.lua
@@ -21,10 +21,19 @@ function M.force_exit_insert_mode()
 end
 
 ---@return nil
-function M.reset_timer()
+function M.clear_timer()
    if timer then
       timer:stop()
+      if timer.close then
+         timer:close()
+      end
+      timer = nil
    end
+end
+
+---@return nil
+function M.reset_timer()
+   M.clear_timer()
    timer = vim.defer_fn(M.force_exit_insert_mode, config.idle_time_ms)
 end
 


### PR DESCRIPTION
## Summary
- reset timers when enabling the plugin
- clear pending timers when disabling
- document new behaviour

## Testing
- `stylua lua/stopinsert/*.lua` *(fails: command not found)*
- `luajit -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684103fccc308328a3c7bdc9b0b80fb5